### PR TITLE
Fix no-op fix_telecined_fades and simplify it

### DIFF
--- a/vsdeinterlace/combing.py
+++ b/vsdeinterlace/combing.py
@@ -5,8 +5,8 @@ from typing import cast
 from vsexprtools import ExprVars, complexpr_available, norm_expr
 from vsrgtools import sbr
 from vstools import (
-    ConvMode, CustomEnum, FieldBasedT, FuncExceptT, FunctionUtil, PlanesT, core, depth, expect_bits,
-    get_neutral_values, scale_8bit, vs
+    MISSING, ConvMode, CustomEnum, FieldBasedT, FuncExceptT, FunctionUtil, MissingT, PlanesT,
+    core, depth, expect_bits, get_neutral_values, scale_8bit, vs
 )
 
 __all__ = [
@@ -17,7 +17,7 @@ __all__ = [
 
 
 def fix_telecined_fades(
-    clip: vs.VideoNode, tff: bool | FieldBasedT | None = None, colors: float | list[float] = 0.0,
+    clip: vs.VideoNode, tff: bool | FieldBasedT | None | MissingT = MISSING, colors: float | list[float] = 0.0,
     planes: PlanesT = None, func: FuncExceptT | None = None
 ) -> vs.VideoNode:
     """
@@ -28,18 +28,19 @@ def fix_telecined_fades(
     Make sure to run this *after* IVTC/deinterlacing!
 
     :param clip:                            Clip to process.
-    :param tff:                             Top-field-first. `False` sets it to Bottom-Field-First.
-                                            If `None`, get the field order from the _FieldBased prop.
+    :param tff:                             This parameter is deprecated and unused. It will be removed in
+                                            the future, so prefer keyword arguments and avoid passing `tff`.
     :param colors:                          Color offset for the plane average.
 
     :return:                                Clip with fades (and only fades) accurately deinterlaced.
-
-    :raises UndefinedFieldBasedError:       No automatic ``tff`` can be determined.
     """
     func = func or fix_telecined_fades
 
     if not complexpr_available:
         raise ExprVars._get_akarin_err()(func=func)
+
+    if tff is not MISSING:
+        print(DeprecationWarning('fix_telecined_fades: The tff parameter is unnecessary and therefore deprecated!'))
 
     f = FunctionUtil(clip, func, planes, (vs.GRAY, vs.YUV), 32)
 

--- a/vsdeinterlace/combing.py
+++ b/vsdeinterlace/combing.py
@@ -61,8 +61,8 @@ def fix_telecined_fades(
     )
 
     fix = norm_expr(
-        props_clip, 'Y 2 % BF! BF@ x.f{t1}Avg{i} x.f{t2}Avg{i} ? AVG! '
-        'AVG@ 0 = x x {color} - AVG@ BF@ x.f{t1}Avg{i} x.f{t2}Avg{i} ? + 2 / AVG@ / * ? {color} +',
+        props_clip, 'Y 2 % x.f{t1}Avg{i} x.f{t2}Avg{i} ? AVG! '
+        'AVG@ 0 = x x {color} - x.ftAvg{i} x.fbAvg{i} + 2 / AVG@ / * ? {color} +',
         planes, i=f.norm_planes, color=colors, force_akarin=func,
         t1='b' if tff.is_tff else 't', t2='t' if tff.is_tff else 'b'
     )

--- a/vsdeinterlace/combing.py
+++ b/vsdeinterlace/combing.py
@@ -21,7 +21,12 @@ def fix_telecined_fades(
     planes: PlanesT = None, func: FuncExceptT | None = None
 ) -> vs.VideoNode:
     """
-    Give a mathematically perfect solution to fades made *after* telecining (which made perfect IVTC impossible).
+    Give a mathematically perfect solution to decombing fades made *after* telecining
+    (which made perfect IVTC impossible) that start or end in a solid color.
+
+    Steps between the frames are not adjusted, so they will remain uneven depending on the telecining pattern,
+    but the decombing is blur-free, ensuring minimum information loss. However, this may cause small amounts
+    of combing to remain due to error amplification, especially near the solid-color end of the fade.
 
     This is an improved version of the Fix-Telecined-Fades plugin.
 
@@ -30,9 +35,10 @@ def fix_telecined_fades(
     :param clip:                            Clip to process.
     :param tff:                             This parameter is deprecated and unused. It will be removed in
                                             the future, so prefer keyword arguments and avoid passing `tff`.
-    :param colors:                          Color offset for the plane average.
+    :param colors:                          Fade source/target color (floating-point plane averages).
 
-    :return:                                Clip with fades (and only fades) accurately deinterlaced.
+    :return:                                Clip with fades to/from `colors` accurately deinterlaced.
+                                            Frames that don't contain such fades may be damaged.
     """
     func = func or fix_telecined_fades
 


### PR DESCRIPTION
Commit 67c08e1f061e0ee4cbd9b9fdec11126d00f645d5 attempted to make `fix_telecined_fades` work for BFF clips to fix #24, but due to a typo, it actually made the function do nothing at all, regardless of field order. Fix this and simplify the expression further to make it easier to maintain and understand.